### PR TITLE
Correct and Reseed

### DIFF
--- a/include/aamcl/AAMCL.h
+++ b/include/aamcl/AAMCL.h
@@ -59,8 +59,11 @@ protected:
   void publish_particles();
   void predict();
   void correct();
+  void reseed();
 
   tf2::Transform add_noise(const tf2::Transform & dm);
+
+  tf2::Transform extract_random_read_with_noise(sensor_msgs::LaserScan & scan, double noise);
 
 private:
   ros::NodeHandle nh_;
@@ -70,7 +73,7 @@ private:
   ros::Subscriber sub_lsr_;
   ros::Subscriber sub_init_pose_;
 
-  static const int NUM_PART = 5;
+  static const int NUM_PART = 50;
 
   std::vector<Particle> particles_;
   bool particles_init;
@@ -94,6 +97,7 @@ private:
   std::default_random_engine generator_;
   std::normal_distribution<double> translation_noise_;
   std::normal_distribution<double> rotation_noise_;
+
 };
 
 }  // namespace aamcl


### PR DESCRIPTION
Hola @aaggj 

He avanzado hasta tener un correct un reseed funcional, aunque le quedan algunos detalles, y muchos de las constantes deberían leerse como parámetros.

Para el correct, he aplicado una idea que me ha venido:
1. No corregimos todo el scan. Seleccionamos aleatoriamente (uniformemente) N rayos.
2. Por cada rayo (dist, ang), le aplicamos el ruido aleatoriamente (gaussiana) que pueda tener a la distancia. Podríamos hacer lo mismo al ángulo.
3. Esta lectura con ruido, la representamos como una TF del láser a un punto laser2point.
4. Como cada partícula es map2bf y tenemos bf2laser, por cada partícula podemos tener un map2point.
5. Por cada partícula obtenemos la (x,y) que contiene su map2point y vemos el coste en el mapa. Si es obstáculo, la probabilidad de la partícula sube, si no, baja

La implementación tiene varias ventajas:
1. Podemos configurar cuántas lecturas se procesan en cada paso, para ser más eficientes.
2. Abre la puerta a usar mapas 3D y que el robot esté inclinado.
3. Somos más exhaustivos añadiendo ruidos
4. No hace falta aplicar el modelo de ruido del sensor al mapa, sino a la observación.

También he hecho el reseed, échale un ojo y lo discutimos esta semana.






Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>